### PR TITLE
Add support for private registries

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,9 +1,15 @@
 package config
 
+import "github.com/docker/docker/api/types"
+
 type Configuration struct {
 	SharePids    bool
 	ShareIpc     bool
 	ShareVolumes bool
 	StreamLogs   bool
 	AlwaysPull   bool
+}
+
+type RegistryAuth struct {
+	Auths map[string]types.AuthConfig `json:"auths"`
 }

--- a/pkg/engine/pull.go
+++ b/pkg/engine/pull.go
@@ -2,11 +2,29 @@ package engine
 
 import (
 	"context"
-	"github.com/docker/docker/api/types"
+	"encoding/base64"
+	"encoding/json"
 	"io"
+	"net/url"
+
+	"github.com/docker/docker/api/types"
 )
 
 func (e *Engine) PullImage(reference string) (io.ReadCloser, error) {
+	var options types.ImagePullOptions
+
+	registryHost := "https://index.docker.io/v1/"
+
+	if parsed, err := url.Parse("docker://" + reference); err == nil {
+		registryHost = parsed.Host
+	}
+
+	if auth, ok := e.auth.Auths[registryHost]; ok {
+		authJson, _ := json.Marshal(auth)
+		encoded := base64.URLEncoding.EncodeToString(authJson)
+		options.RegistryAuth = encoded
+	}
+
 	// TODO is context.Background() appropriate here?
-	return e.api.ImagePull(context.Background(), reference, types.ImagePullOptions{})
+	return e.api.ImagePull(context.Background(), reference, options)
 }

--- a/pkg/engine/types.go
+++ b/pkg/engine/types.go
@@ -2,11 +2,14 @@ package engine
 
 import (
 	"context"
+
 	"github.com/docker/docker/client"
+	"github.com/rycus86/podlike/pkg/config"
 )
 
 type Engine struct {
 	api *client.Client
+	auth *config.RegistryAuth
 
 	cancelEvents context.CancelFunc
 }


### PR DESCRIPTION
This commit adds support for private registries, using `/var/run/secrets/dockerregistryauth.json` (I'm not sure if this is the proper file name - could be changed or maybe controlled via env variable?) file. This file should be compatible with docker's config.json or [dockerconfigjson secret from kubernetes]

[dockerconfigjson secret from kubernetes]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

For now no documentation updates as I don't know if this project is still alive and if it is worth to write any docs.

Fixes #6